### PR TITLE
hide menu when zero filtered items, this prevents erroneous errors wh…

### DIFF
--- a/js/tribute.js
+++ b/js/tribute.js
@@ -178,6 +178,11 @@ if (!Array.prototype.find) {
 
       this.current.filteredItems = items
 
+      if(!items.length) {
+        this.hideMenu();
+        return;
+      }
+
       let ul = this.menu.querySelector('ul')
 
       ul.innerHTML = ''


### PR DESCRIPTION
The issue is illustrated [here](http://plnkr.co/edit/zndWka?p=preview)

Typing the trigger and continue typing until the list is empty, then hit the tab or enter, this causes `selectTemplate` to be called with `item` undefined

This throws unnecessary errors and prevents further propagation.  This patch will reset the menu when the list is empty.