### PR TITLE
fix click on <li> desdendants

### DIFF
--- a/js/tribute.js
+++ b/js/tribute.js
@@ -323,6 +323,12 @@ if (!Array.prototype.find) {
 
       if (tribute.menu && tribute.menu.contains(event.target)) {
         let li = event.target
+        while (li.nodeName.toLowerCase() !== 'li') {
+           li = li.parentNode;
+           if (!li || li === tribute.menu) {
+             throw new Error('cannot find the <li> container for the click');
+           }
+        }
         tribute.selectItemAtIndex(li.getAttribute('data-index'))
         tribute.hideMenu()
       } else if (tribute.current.element) {


### PR DESCRIPTION
While testing `example/index.html` on a contentEditable element I ran into the error

**`Uncaught TypeError: Cannot read property 'original' of undefined`**

It appears that it's  caused by a click on a `<span>` inside the `<li>` of the tribute menu.