### PR TITLE
Add noMatchTemplate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,16 @@ document.getElementById('myElement').addEventListener('tribute-replaced', functi
 });
 ```
 
+### No Match Event
+You can bind to the `tribute-no-match` event to know when no match is found in your collection.
+
+If your element has an ID of `myElement`:
+```js
+document.getElementById('myElement').addEventListener('tribute-no-match', function (e) {
+  console.log('No match found!');
+});
+```
+
 ## Tips
 Some useful approaches to common roadblocks when implementing @mentions.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Collection object shown with defaults:
     return item.string;
   },
 
+  // template for when no match is found (optional),
+  // If not template provided, menu is hidden.
+  noMatchTemplate: null,
+
   // specify an alternative parent container for the menu
   menuContainer: document.body,
 

--- a/dist/tribute.js
+++ b/dist/tribute.js
@@ -292,6 +292,32 @@ if (!Array.prototype.find) {
         value: function replaceText(content) {
           this.range.replaceTriggerText(content, true, true);
         }
+      }, {
+        key: '_append',
+        value: function _append(collection, element, newValues, replace) {
+          if (this.isActive) {
+            if (!replace) {
+              collection.values = collection.values.concat(newValues);
+            } else {
+              collection.values = newValues;
+            }
+          }
+        }
+      }, {
+        key: 'append',
+        value: function append(collectionIndex, newValues, replace) {
+          var index = parseInt(collectionIndex);
+          if (typeof index !== 'number') throw new Error('please provide an index for the collection to update.');
+
+          var collection = this.collection[index];
+
+          this._append(this.current.collection, this.current.element, newValues, replace);
+        }
+      }, {
+        key: 'appendCurrent',
+        value: function appendCurrent(newValues, replace) {
+          this._append(this.current.collection, this.current.element, newValues, replace);
+        }
       }], [{
         key: 'defaultSelectTemplate',
         value: function defaultSelectTemplate(item) {

--- a/dist/tribute.js
+++ b/dist/tribute.js
@@ -475,7 +475,7 @@ if (!Array.prototype.find) {
             if ((typeof _ret2 === 'undefined' ? 'undefined' : _typeof(_ret2)) === "object") return _ret2.v;
           }
 
-          if (instance.tribute.current.trigger && instance.commandEvent === false) {
+          if (instance.tribute.current.trigger && instance.commandEvent === false || instance.tribute.isActive && event.keyCode === 8) {
             instance.tribute.showMenuFor(this);
           }
         }
@@ -587,6 +587,8 @@ if (!Array.prototype.find) {
             delete: function _delete(e, el) {
               if (_this6.tribute.isActive && _this6.tribute.current.mentionText.length < 1) {
                 _this6.tribute.hideMenu();
+              } else if (_this6.tribute.isActive) {
+                tribute.showMenuFor(el);
               }
             }
           };

--- a/dist/tribute.js
+++ b/dist/tribute.js
@@ -282,7 +282,8 @@ if (!Array.prototype.find) {
       }, {
         key: 'selectItemAtIndex',
         value: function selectItemAtIndex(index) {
-          if (!index) return;
+          index = parseInt(index);
+          if (typeof index !== 'number') return;
           var item = this.current.filteredItems[index];
           var content = this.current.collection.selectTemplate(item);
           this.replaceText(content);

--- a/dist/tribute.js
+++ b/dist/tribute.js
@@ -244,6 +244,8 @@ if (!Array.prototype.find) {
           var ul = this.menu.querySelector('ul');
 
           if (!items.length) {
+            var noMatchEvent = new CustomEvent('tribute-no-match', { detail: this.menu });
+            this.current.element.dispatchEvent(noMatchEvent);
             if (!this.current.collection.noMatchTemplate) {
               this.hideMenu();
             } else {

--- a/dist/tribute.js
+++ b/dist/tribute.js
@@ -71,6 +71,8 @@ if (!Array.prototype.find) {
         var collection = _ref$collection === undefined ? null : _ref$collection;
         var _ref$menuContainer = _ref.menuContainer;
         var menuContainer = _ref$menuContainer === undefined ? null : _ref$menuContainer;
+        var _ref$noMatchTemplate = _ref.noMatchTemplate;
+        var noMatchTemplate = _ref$noMatchTemplate === undefined ? null : _ref$noMatchTemplate;
 
         _classCallCheck(this, Tribute);
 
@@ -92,7 +94,17 @@ if (!Array.prototype.find) {
             // function called on select that retuns the content to insert
             selectTemplate: (selectTemplate || Tribute.defaultSelectTemplate).bind(this),
 
+            // function called that returns content for an item
             menuItemTemplate: (menuItemTemplate || Tribute.defaultMenuItemTemplate).bind(this),
+
+            // function called when menu is empty, disables hiding of menu.
+            noMatchTemplate: function (t) {
+              if (typeof t === 'function') {
+                return t.bind(_this);
+              }
+
+              return null;
+            }(noMatchTemplate),
 
             // column to search against in the object
             lookup: lookup,
@@ -111,6 +123,14 @@ if (!Array.prototype.find) {
               selectClass: item.selectClass || selectClass,
               selectTemplate: (item.selectTemplate || Tribute.defaultSelectTemplate).bind(_this),
               menuItemTemplate: (item.menuItemTemplate || Tribute.defaultMenuItemTemplate).bind(_this),
+              // function called when menu is empty, disables hiding of menu.
+              noMatchTemplate: function (t) {
+                if (typeof t === 'function') {
+                  return t.bind(_this);
+                }
+
+                return null;
+              }(noMatchTemplate),
               lookup: item.lookup || lookup,
               fillAttr: item.fillAttr || fillAttr,
               values: item.values
@@ -221,12 +241,17 @@ if (!Array.prototype.find) {
 
           this.current.filteredItems = items;
 
+          var ul = this.menu.querySelector('ul');
+
           if (!items.length) {
-            this.hideMenu();
+            if (!this.current.collection.noMatchTemplate) {
+              this.hideMenu();
+            } else {
+              ul.innerHTML = this.current.collection.noMatchTemplate();
+            }
+
             return;
           }
-
-          var ul = this.menu.querySelector('ul');
 
           ul.innerHTML = '';
 
@@ -255,6 +280,7 @@ if (!Array.prototype.find) {
       }, {
         key: 'selectItemAtIndex',
         value: function selectItemAtIndex(index) {
+          if (!index) return;
           var item = this.current.filteredItems[index];
           var content = this.current.collection.selectTemplate(item);
           this.replaceText(content);

--- a/example/index.html
+++ b/example/index.html
@@ -143,7 +143,8 @@
       });
 
       document.getElementById('test').addEventListener('tribute-no-match', function (e) {
-        console.log('no match');
+        var values = [{key: 'Cheese Tacos', value: 'Cheese Tacos', email: 'cheesetacos@zurb.com'}];
+        tribute.appendCurrent(values);
       });
     </script>
   </body>

--- a/example/index.html
+++ b/example/index.html
@@ -78,6 +78,9 @@
           {key: 'Jordan Humphreys', value: 'Jordan Humphreys', email: 'getstarted@zurb.com'},
           {key: 'Sir Walter Riley', value: 'Sir Walter Riley', email: 'getstarted+riley@zurb.com'}
         ],
+        noMatchTemplate: function (tribute) {
+          return '<li>No match!</li>';
+        },
         selectTemplate: function (item) {
           if (this.range.isContentEditable(this.current.element)) {
             return '<span contenteditable="false"><a href="http://zurb.com" target="_blank" title="' + item.original.email + '">' + item.original.value + '</a></span>';

--- a/example/index.html
+++ b/example/index.html
@@ -141,6 +141,10 @@
       document.getElementById('test').addEventListener('tribute-replaced', function (e) {
         console.log('Text replaced by Tribute!');
       });
+
+      document.getElementById('test').addEventListener('tribute-no-match', function (e) {
+        console.log('no match');
+      });
     </script>
   </body>
 </html>

--- a/js/tribute.js
+++ b/js/tribute.js
@@ -215,6 +215,8 @@ if (!Array.prototype.find) {
       let ul = this.menu.querySelector('ul')
 
       if (!items.length) {
+        let noMatchEvent = new CustomEvent('tribute-no-match', { detail: this.menu })
+        this.current.element.dispatchEvent(noMatchEvent)
         if (!this.current.collection.noMatchTemplate) {
           this.hideMenu()
         } else {

--- a/js/tribute.js
+++ b/js/tribute.js
@@ -261,6 +261,30 @@ if (!Array.prototype.find) {
     replaceText(content) {
       this.range.replaceTriggerText(content, true, true)
     }
+
+    _append(collection, element, newValues, replace) {
+      if (this.isActive) {
+        if (!replace) {
+          collection.values = collection.values.concat(newValues)
+        } else {
+          collection.values = newValues
+        }
+      }
+    }
+
+    append(collectionIndex, newValues, replace) {
+      let index = parseInt(collectionIndex)
+      if (typeof index !== 'number') throw new Error('please provide an index for the collection to update.')
+
+      let collection = this.collection[index]
+
+      this._append(this.current.collection, this.current.element, newValues, replace)
+    }
+
+    appendCurrent(newValues, replace) {
+      this._append(this.current.collection, this.current.element, newValues, replace)
+    }
+
   }
 
   class TributeMenuEvents {

--- a/js/tribute.js
+++ b/js/tribute.js
@@ -252,7 +252,8 @@ if (!Array.prototype.find) {
     }
 
     selectItemAtIndex(index) {
-      if (!index) return
+      index = parseInt(index)
+      if (typeof index !== 'number') return
       let item = this.current.filteredItems[index]
       let content = this.current.collection.selectTemplate(item)
       this.replaceText(content)

--- a/js/tribute.js
+++ b/js/tribute.js
@@ -410,7 +410,8 @@ if (!Array.prototype.find) {
         }
       }
 
-      if (instance.tribute.current.trigger && instance.commandEvent === false) {
+      if (instance.tribute.current.trigger && instance.commandEvent === false
+        || instance.tribute.isActive && event.keyCode === 8) {
         instance.tribute.showMenuFor(this)
       }
     }
@@ -516,6 +517,8 @@ if (!Array.prototype.find) {
         delete: (e, el) => {
           if (this.tribute.isActive && this.tribute.current.mentionText.length < 1) {
             this.tribute.hideMenu();
+          } else if (this.tribute.isActive) {
+            tribute.showMenuFor(el)
           }
         }
       }


### PR DESCRIPTION
Allow users to specify a template to display when no match is found. This also adds a `tribute-no-match` event when nothing is found. The event fires whether or not you have specified a `noMatchTemplate`.