### PR TITLE
vue-tribute - Vue.js wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ That's it! Now you can use the `example/index.html` to test out changes to the c
 
 Once you have made your changes, feel free to submit a pull request.
 
+## Framework Support
+
+Vue.js — [vue-tribute](https://github.com/syropian/vue-tribute) by **@syropian**
+
 **What's next**
 
 The major focus that we could use your help with is creating wrappers for different JavaScript frameworks. Some of the ones we are interested in are outlined below. We also see a couple of areas for improving compatability with different rendering situations, such as in iframes inside of rich text editors.


### PR DESCRIPTION
Adds a new section & link in the readme to [vue-tribute](https://github.com/syropian/vue-tribute) — A Vue.js wrapper for Tribute. 

@mrsweaters, if you you want that section in the readme in a different spot, or the links displayed differently, please let me know, and I'll fix it up 😄 