### PR TITLE
Fix a shadow DOM issue where the menu could not be displayed

### DIFF
--- a/src/TributeRange.js
+++ b/src/TributeRange.js
@@ -218,7 +218,7 @@ class TributeRange {
             text = ''
 
         if (!this.isContentEditable(context.element)) {
-            let textComponent = this.getDocument().activeElement
+            let textComponent = this.tribute.current.element;
             if (textComponent) {
                 let startPos = textComponent.selectionStart
                 if (textComponent.value && startPos >= 0) {


### PR DESCRIPTION
Replace `this.getDocument().activeElement` with `this.tribute.current.element` to fix a bug in shadow DOM, where the menu could not be shown. Because `this.getDocument().activeElement` was not the native input element.