### PR TITLE
Fixed bug on detaching Tribute

### DIFF
--- a/src/Tribute.js
+++ b/src/Tribute.js
@@ -400,12 +400,16 @@ class Tribute {
 
     _detach(el) {
         this.events.unbind(el)
-        this.menuEvents.unbind(el.tributeMenu)
+        if (el.tributeMenu) {
+            this.menuEvents.unbind(el.tributeMenu)
+        }
 
         setTimeout(() => {
             el.removeAttribute('data-tribute')
             this.isActive = false
-            el.tributeMenu.remove()
+            if (el.tributeMenu) {
+                el.tributeMenu.remove()
+            }
         })
     }
 }


### PR DESCRIPTION
If Tribute is attached but the menu is never opened, then el.tributeMenu will not be set and you get an error when trying to detach it.