### PR TITLE
More compatible TypeScript definition file

### DIFF
--- a/tributejs.d.ts
+++ b/tributejs.d.ts
@@ -57,14 +57,14 @@ export type TributeOptions<T> = TributeCollection<T> | {
   collection: Array<TributeCollection<{ [key: string]: any }>>
 }
 
-export default class Tribute {
-  constructor<T extends {}>(options: TributeOptions<T>)
+export default class Tribute<T extends {}> {
+  constructor(options: TributeOptions<T>)
 
   isActive: boolean
 
-  append<T extends {}>(index: number, values: Array<T>, replace?: boolean): void
+  append(index: number, values: Array<T>, replace?: boolean): void
 
-  appendCurrent<T extends {}>(values: Array<T>, replace?: boolean): void
+  appendCurrent(values: Array<T>, replace?: boolean): void
 
   attach(to: Element): void
 


### PR DESCRIPTION
Providing type on the class level should be fully sufficient, as you rather don't want to change types of items on an existing `Tribute` instance. In addition, the style suggested in this PR works with TypeScript 2.7 (current typing on `constructor` doesn't), which is used by the latest Angular@6