### PR TITLE
Adds readme message explaining optional index for showMenuForCollection

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,11 @@ activateLink.addEventListener('mousedown', function (e) {
 });
 ```
 
+Note that `showMenuForCollection` has an optional second parameter called `collectionIndex` that defaults to 0. This allows you to specify which collection you want to trigger with the first index starting at 0.
+
+For example, if you want to trigger the second collection you would use the following snippet: `tribute.showMenuForCollection(input, 1);`
+
+
 ## Events
 
 ### Replaced


### PR DESCRIPTION
Updates readme to explain optional index for `showMenuForCollection` as @jamauro first mentioned in issue #185 

![screen shot 2019-02-08 at 4 47 59 pm](https://user-images.githubusercontent.com/310231/52508080-5e29f000-2bc1-11e9-90f8-8bb32966e57e.png)
