### PR TITLE
Add more info to the tribute-replaced event detail

### DIFF
--- a/src/TributeRange.js
+++ b/src/TributeRange.js
@@ -113,18 +113,19 @@ class TributeRange {
     }
 
     replaceTriggerText(text, requireLeadingSpace, hasTrailingSpace, originalEvent, item) {
-        let context = this.tribute.current
         let info = this.getTriggerInfo(true, hasTrailingSpace, requireLeadingSpace, this.tribute.allowSpaces, this.tribute.autocompleteMode)
 
-        // Create the event
-        let replaceEvent = new CustomEvent('tribute-replaced', {
-            detail: {
-                item: item,
-                event: originalEvent
-            }
-        })
-
         if (info !== undefined) {
+            let context = this.tribute.current
+            let replaceEvent = new CustomEvent('tribute-replaced', {
+                detail: {
+                    item: item,
+                    instance: context,
+                    context: info,
+                    event: originalEvent,
+                }
+            })
+
             if (!this.isContentEditable(context.element)) {
                 let myField = this.tribute.current.element
                 let textSuffix = typeof this.tribute.replaceTextSuffix == 'string'


### PR DESCRIPTION
Hey there!

It's often useful having access on more information on this event. I specially need to know the trigger char here, since you can have multiple triggers enabled.

Also, I think it'd be nice to have access to the collection itself, too.