### PR TITLE
Small performance improvement + Allow limiting the number of shown items in the menu

### DIFF
--- a/src/Tribute.js
+++ b/src/Tribute.js
@@ -257,6 +257,7 @@ class Tribute {
             }
 
             ul.innerHTML = ''
+            let fragment = this.range.getDocument().createDocumentFragment()
 
             items.forEach((item, index) => {
                 let li = this.range.getDocument().createElement('li')
@@ -272,8 +273,9 @@ class Tribute {
                   li.className = this.current.collection.selectClass
                 }
                 li.innerHTML = this.current.collection.menuItemTemplate(item)
-                ul.appendChild(li)
+                fragment.appendChild(li)
             })
+            ul.appendChild(fragment)
         }
 
         if (typeof this.current.collection.values === 'function') {

--- a/src/Tribute.js
+++ b/src/Tribute.js
@@ -24,6 +24,7 @@ class Tribute {
         positionMenu = true,
         spaceSelectsMatch = false,
         searchOpts = {},
+        menuItemLimit = null,
     }) {
         this.autocompleteMode = autocompleteMode
         this.menuSelected = 0
@@ -79,7 +80,9 @@ class Tribute {
 
                 requireLeadingSpace: requireLeadingSpace,
 
-                searchOpts: searchOpts
+                searchOpts: searchOpts,
+
+                menuItemLimit: menuItemLimit,
             }]
         }
         else if (collection) {
@@ -104,7 +107,8 @@ class Tribute {
                     fillAttr: item.fillAttr || fillAttr,
                     values: item.values,
                     requireLeadingSpace: item.requireLeadingSpace,
-                    searchOpts: item.searchOpts || searchOpts
+                    searchOpts: item.searchOpts || searchOpts,
+                    menuItemLimit: item.menuItemLimit || menuItemLimit,
                 }
             })
         }
@@ -254,6 +258,10 @@ class Tribute {
                 }
 
                 return
+            }
+
+            if (this.current.collection.menuItemLimit) {
+                items = items.slice(0, this.current.collection.menuItemLimit)
             }
 
             ul.innerHTML = ''


### PR DESCRIPTION
Hi there,

Performance is not ideal when you have hundreds of items to show on the menu.

`menuItemLimit` will allow limiting the number of items shown to, say, 5 or 10 items. Searching still works as expected, so the user the keep typing to see items not shown in the list instead of scrolling.

This is a must for mobile devices.