### PR TITLE
Update CSS application manifest example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Then, add the following to `app/assets/javascripts/application.js`:
 And in `app/assets/stylesheets/application.css`:
 
 ```css
-//= require tribute
+//= require tribute/index
 ```
 
 ### Webpack


### PR DESCRIPTION
SassC throws an error when including only `tribute` in the manifest. Including `tribute/index` loads the styles and should be safe for regular versions of Sass as well.

Also updated in zurb/tribute-rb#3 as well.