### PR TITLE
Fix type definition of lookup: function has 2nd argument.

### DIFF
--- a/tributejs.d.ts
+++ b/tributejs.d.ts
@@ -36,7 +36,7 @@ export type TributeCollection<T extends {}> = {
   menuContainer?: Element
 
   // column to search against in the object (accepts function or string)
-  lookup?: string | ((item: T) => string)
+  lookup?: string | ((item: T, mentionText: string) => string)
 
   // column that contains the content to insert by default
   fillAttr?: string


### PR DESCRIPTION
If lookup is a function it is called with two arguments. This fixes the type definition to match that behaviour.