### PR TITLE
Add configuration to set list item class

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ Collection object shown with defaults:
   // class added to the menu container
   containerClass: 'tribute-container',
 
+  // class added to each list item
+  itemClass: '',
+
   // function called on select that returns the content to insert
   selectTemplate: function (item) {
     return '@' + item.original.value;

--- a/src/Tribute.js
+++ b/src/Tribute.js
@@ -10,6 +10,7 @@ class Tribute {
         iframe = null,
         selectClass = 'highlight',
         containerClass = 'tribute-container',
+        itemClass = '',
         trigger = '@',
         autocompleteMode = false,
         selectTemplate = null,
@@ -58,6 +59,9 @@ class Tribute {
                 // class applied to the Container 
                 containerClass: containerClass,
 
+                // class applied to each item
+                itemClass: itemClass,
+
                 // function called on select that retuns the content to insert
                 selectTemplate: (selectTemplate || Tribute.defaultSelectTemplate).bind(this),
 
@@ -98,6 +102,7 @@ class Tribute {
                     iframe: item.iframe || iframe,
                     selectClass: item.selectClass || selectClass,
                     containerClass: item.containerClass || containerClass,
+                    itemClass: item.itemClass || itemClass,
                     selectTemplate: (item.selectTemplate || Tribute.defaultSelectTemplate).bind(this),
                     menuItemTemplate: (item.menuItemTemplate || Tribute.defaultMenuItemTemplate).bind(this),
                     // function called when menu is empty, disables hiding of menu.
@@ -275,6 +280,7 @@ class Tribute {
             items.forEach((item, index) => {
                 let li = this.range.getDocument().createElement('li')
                 li.setAttribute('data-index', index)
+                li.className = this.current.collection.itemClass
                 li.addEventListener('mousemove', (e) => {
                     let [li, index] = this._findLiTarget(e.target)
                     if (e.movementY !== 0) {
@@ -282,7 +288,7 @@ class Tribute {
                     }
                 })
                 if (this.menuSelected === index) {
-                  li.className = this.current.collection.selectClass
+                  li.classList.add(this.current.collection.selectClass)
                 }
                 li.innerHTML = this.current.collection.menuItemTemplate(item)
                 fragment.appendChild(li)

--- a/test/spec/test.js
+++ b/test/spec/test.js
@@ -97,6 +97,32 @@ describe('Tribute @mentions cases', function () {
 
         detachTribute(tribute, input.id);
       });
+
+      it('should add itemClass to list items when set it config', () => {
+
+        let input = createDomElement(elementType);
+
+        let collectionObject = {
+          trigger: trigger,
+          itemClass: 'mention-list-item',
+          selectClass: 'mention-selected',
+          values: [
+            { key: 'Jordan Humphreys', value: 'Jordan Humphreys', email: 'getstarted@zurb.com' },
+            { key: 'Sir Walter Riley', value: 'Sir Walter Riley', email: 'getstarted+riley@zurb.com' }
+          ],
+        }
+
+        let tribute = attachTribute(collectionObject, input.id);
+
+        fillIn(input, ' ' + trigger);
+        let popupList = document.querySelectorAll('.tribute-container > ul > li');
+        expect(popupList.length).toBe(2);
+
+        expect(popupList[0].className).toBe('mention-list-item mention-selected');
+        expect(popupList[1].className).toBe('mention-list-item');
+
+        detachTribute(tribute, input.id);
+      });
     });
   });
 });

--- a/tributejs.d.ts
+++ b/tributejs.d.ts
@@ -22,6 +22,8 @@ export type TributeCollection<T extends {}> = {
   // class added in the flyout menu for active item
   containerClass?: string
 
+  itemClass?: string
+
   // function called on select that returns the content to insert
   selectTemplate?: (item: TributeItem<T>) => string
 


### PR DESCRIPTION
I'd like to be able to set a specific class on each `li` in the list of results, in order to style the list better.  This PR adds an `itemClass` configuration option which will be applied to each `li` element when the list is created in the DOM.