### PR TITLE
Add menuItemLimit to README and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ Collection object shown with defaults:
     skip: false // true will skip local search, useful if doing server-side search
   },
 
+  // Limits the number of items in the menu
+  menuItemLimit: 25,
+
   // specify the minimum number of characters that must be typed before menu appears
   menuShowMinLength: 0
 }

--- a/tributejs.d.ts
+++ b/tributejs.d.ts
@@ -71,6 +71,9 @@ export type TributeCollection<T extends {}> = {
   // Customize the elements used to wrap matched strings within the results list
   searchOpts?: TributeSearchOpts;
 
+  // Limits the number of items in the menu
+  menuItemLimit?: number;
+
   // require X number of characters to be entered before menu shows
   menuShowMinLength?: number;
 };


### PR DESCRIPTION
This feature was added some months ago, but the documentation from the README was missing. As it happens we did have a need for this feature so I was pleasantly surprised to find it in the code. 👍 