### PR TITLE
Add some aria attribute to dropdown for accessibility purposes

### DIFF
--- a/src/Tribute.js
+++ b/src/Tribute.js
@@ -261,6 +261,8 @@ class Tribute {
     let wrapper = this.range.getDocument().createElement("div"),
       ul = this.range.getDocument().createElement("ul");
     wrapper.className = containerClass;
+    wrapper.setAttribute('aria-expanded','true');
+    ul.setAttribute('id','results');
     wrapper.appendChild(ul);
 
     if (this.menuContainer) {
@@ -353,6 +355,7 @@ class Tribute {
 
       items.forEach((item, index) => {
         let li = this.range.getDocument().createElement("li");
+        li.setAttribute('role', 'option');
         li.setAttribute("data-index", index);
         li.className = this.current.collection.itemClass;
         li.addEventListener("mousemove", e => {


### PR DESCRIPTION
### Purpose

While working on a side projecte that uses Tribute.js to implement an user's dropdown list to add into a list, I was asked to add some aria's accessibility functionality to input and its dropdown list.
I realised I was unable to link the dropdown <ul element to the input with an "aria-owns" attribute because <ul element lacks of ii, as well as the <li element neither had 'role="option"'

### Accessibility functions

As an example, I was following some aria best practices like these:
- https://haltersweb.github.io/Accessibility/autocomplete.html

### :camera: Screenshots

Now:

![image](https://user-images.githubusercontent.com/9702463/82019584-c9e1ef00-9687-11ea-9471-3e48a5fcaa97.png)

With aria attributes:

![image](https://user-images.githubusercontent.com/9702463/82020229-ffd3a300-9688-11ea-83b4-35b8e49f50df.png)
