### PR TITLE
Fixed wrong `if (window)` check

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -21,7 +21,7 @@ if (!Array.prototype.find) {
     }
 }
 
-if (window && typeof window.CustomEvent !== "function") {
+if (typeof window !== 'undefined' && typeof window.CustomEvent !== "function") {
   function CustomEvent(event, params) {
     params = params || {
       bubbles: false,


### PR DESCRIPTION
`if (window)` it is incorrect check that throws `ReferenceError` error in non-browser environment. When you want to check potentially uninitialised variable, you must do it using typeof construction. Btw, i'm getting `ReferenceError: window is not defined` when i just imported tribute (w/o `new Tribute`) in Node js (server side rendering). It's strange, i supposed, that initialisation runs after i call `new Tribute`.