### PR TITLE
Fix `spaceSelectsMatch` causing error (fixes #495)

### DIFF
--- a/src/TributeEvents.js
+++ b/src/TributeEvents.js
@@ -107,7 +107,7 @@ class TributeEvents {
     }
     instance.updateSelection(this);
 
-    if (event.keyCode === 27) return;
+    if (!event.keyCode || event.keyCode === 27) return;
 
     if (!instance.tribute.allowSpaces && instance.tribute.hasTrailingSpace) {
       instance.tribute.hasTrailingSpace = false;


### PR DESCRIPTION
With `spaceSelectsMatch` enabled, an error `Uncaught TypeError: Cannot read property '0' of undefined` is sometimes given when attempting to autocomplete with any of space, tab, or enter.

The cause appears to be that with this option enabled, sometimes this code path intended to handle KeyboardEvents will be entered again after handling a KeyboardEvent with another type of event (CustomEvent); this then later causes this error as `this.current.filteredItems` is now `undefined`, as the original KeyboardEvent has already been handled.

Checking whether the event looks like a KeyboardEvent, and returning early if it doesn't, appears to resolve this.

Before this change with `spaceSelectsMatch` enabled:
![error_before_change](https://user-images.githubusercontent.com/7476523/88739027-69fccf80-d131-11ea-8e27-a503413f10cf.gif)

After this change with `spaceSelectsMatch` enabled:
![no_error_after_change](https://user-images.githubusercontent.com/7476523/88739067-80a32680-d131-11ea-91b9-c9230b6e925f.gif)
