### PR TITLE
Fix trigger char not getting removed when replaceTextSuffix is empty …

### DIFF
--- a/src/TributeRange.js
+++ b/src/TributeRange.js
@@ -138,7 +138,7 @@ class TributeRange {
                     : ' '
                 text += textSuffix
                 let startPos = info.mentionPosition
-                let endPos = info.mentionPosition + info.mentionText.length + textSuffix.length
+                let endPos = info.mentionPosition + info.mentionText.length + (textSuffix === '' ? 1 : textSuffix.length)
                 if (!this.tribute.autocompleteMode) {
                     endPos += info.mentionTriggerChar.length - 1
                 }


### PR DESCRIPTION
This fixes issue mentioned in #274 
When we set replaceTextSuffix to empty string (''), the trigger character @ will not get replaced. 

