### PR TITLE
Fix array index out of bounds on enter key event

### DIFF
--- a/src/TributeEvents.js
+++ b/src/TributeEvents.js
@@ -223,7 +223,8 @@ class TributeEvents {
       },
       enter: (e, el) => {
         // choose selection
-        if (this.tribute.isActive && this.tribute.current.filteredItems) {
+        const filteredItems = this.tribute.current.filteredItems;
+        if (this.tribute.isActive && filteredItems && filteredItems.length) {
           e.preventDefault();
           e.stopPropagation();
           setTimeout(() => {


### PR DESCRIPTION
On keyboard enter, don't select when filteredItems is empty.

If `filteredItems` is empty array here:
https://github.com/zurb/tribute/blob/252ec344a75b624268aef1cdbf80afc30b3cbe2b/src/TributeEvents.js#L226-L230

Then `item` will be undefined here:
https://github.com/zurb/tribute/blob/252ec344a75b624268aef1cdbf80afc30b3cbe2b/src/Tribute.js#L473-L479

I noticed this when hitting the enter key on strings that don't match any values but coincidentally contain my trigger character, e.g. `:` in hyperlinks.