### PR TITLE
lastIndexWithoutLeadingSpace (lastIndexOf replacement)

### DIFF
--- a/src/TributeRange.js
+++ b/src/TributeRange.js
@@ -307,7 +307,7 @@ class TributeRange {
                 let c = config.trigger
                 let idx = config.requireLeadingSpace ?
                     this.lastIndexWithLeadingSpace(effectiveRange, c) :
-                    effectiveRange.lastIndexOf(c)
+                    this.lastIndexWithoutLeadingSpace(effectiveRange, c)
 
                 if (idx > mostRecentTriggerCharPos) {
                     mostRecentTriggerCharPos = idx
@@ -382,6 +382,18 @@ class TributeRange {
         }
 
         return index
+    }
+
+    lastIndexWithoutLeadingSpace (str, trigger) {
+        let index = str.lastIndexOf(trigger);
+
+        if (index > -1) {
+          while (str.substring(index - trigger.length, index) === trigger) {
+            index -= trigger.length;
+          }
+        }
+
+        return index;
     }
 
     isContentEditable(element) {


### PR DESCRIPTION
**Usecase:** 

- `trigger: '{'`

**When Tribute is configured with `requireLeadingSpace: true`**, it's possible to start typing a mention like this: 

> Lorem 
> Lorem ipsum
> Lorem ipsum { `// => triggered`

And if we add another trigger: 

> Lorem ipsum {{ `// => triggered`
> Lorem ipsum {{{ `// => triggered`

The replacement will be effective considering the space before the `trigger` (`lastIndexWithLeadingSpace`).
The replacement is effective and works with multiple consecutive triggers.

**When Tribute is configured with `requireLeadingSpace: false`**, it's possible to start typing a mention like this: 

> Lorem 
> Lorem ipsum
> Lorem ipsum{ `// => triggered`

But if we add another trigger: 

> Lorem ipsum{{ `// => triggered`
> Lorem ipsum{{{ `// => triggered`

The replacement will be effective considering the last `trigger` only (`lastIndexOf`).
With the new `lastIndexWithoutLeadingSpace` method, the replacement is effective in the exact same way and works with multiple consecutive triggers.